### PR TITLE
Fix: Generate model name

### DIFF
--- a/assets/gii.js
+++ b/assets/gii.js
@@ -240,7 +240,7 @@ yii.gii = (function ($) {
                 }
                 if ($('#generator-modelclass').val() === '' && tableName && tableName.indexOf('*') === -1) {
                     var modelClass = '';
-                    $.each(tableName.split('_'), function() {
+                    $.each(tableName.split(/\.|\_/), function() {
                         if(this.length>0)
                             modelClass+=this.substring(0,1).toUpperCase()+this.substring(1);
                     });


### PR DESCRIPTION
When you use PostgreSQL and typing with schema name you will get error in modelClass and queryClass field, if the checkbox of the generateQuery will be unset you won't see any errors but nothing happend, form won't be send

При использовании PostgreSQL если вписать название таблицы вместе со схемой то значение поля будет перенесено в modelClass и queryClass криво (к примеру: user.log получим User.log, но точку в названии модели использовать нельзя), но если modelClass мы видим сразу и правим ошибку, то queryClass скрыто по умолчанию и ошибку не видно из-за чего при нажатии на preview ничего не произойдет

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | yes
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | comma-separated list of tickets # fixed by the PR, if any
